### PR TITLE
feat/citoid - Support for CITOID_URL env parameter and development environment

### DIFF
--- a/conf/LocalSettings/extensions/Cite.php
+++ b/conf/LocalSettings/extensions/Cite.php
@@ -4,14 +4,16 @@ wfLoadExtension( 'Cite' );          // Enable citation features.
 wfLoadExtension( 'TemplateData' );  // Add template documentation for VisualEditor.
 wfLoadExtension( 'Citoid' );        // Enable automatic citation generation.
 
+# Enable citoid, if configured
+if(getenv("CITOID_URL")) {
 # Enable citation templates and reference features.
-$wgVisualEditorEnableCitations = true;         // Enable citation tools in VisualEditor.
-$wgCiteVisualEditorOtherGroup = true;          // Group "other" citation templates.
-$wgVisualEditorEnableReferences = true;        // Enable references in VisualEditor.
+    $wgVisualEditorEnableCitations = true;         // Enable citation tools in VisualEditor.
+    $wgCiteVisualEditorOtherGroup = true;          // Group "other" citation templates.
+    $wgVisualEditorEnableReferences = true;        // Enable references in VisualEditor.
 
-# Allow import of citation templates from Wikipedia for better citation functionality.
-$wgImportSources = [ 'wikipedia' ];
+    # Allow import of citation templates from Wikipedia for better citation functionality.
+    $wgImportSources = [ 'wikipedia' ];
 
-# Configure Citoid service for automatic citation generation.
-$wgCitoidServiceUrl = "https://citoid.wikimedia.org/api";  // URL for the Citoid API.
-$wgVisualEditorEnableCitoidSupport = true;                // Enable automatic citation features in VisualEditor.
+    $wgCitoidServiceUrl = getenv("CITOID_URL");  // URL for the Citoid API.
+    $wgVisualEditorEnableCitoidSupport = true;                // Enable automatic citation features in VisualEditor.
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - WIKI_CAPTCHA_KEY
       - WIKI_CAPTCHA_SITE
       - REDIS_SERVER=crw-local-cache:6379
+      - CITOID_URL=http://localhost:${CITOID_PORT}
     depends_on:
       crw-local-db:
         condition: service_started
@@ -47,3 +48,7 @@ services:
   crw-local-cache:
     image: redis:8-bookworm
     restart: always
+  crw-citoid:
+    image: docker-registry.wikimedia.org/wikimedia/mediawiki-services-citoid:2025-10-28-154741-production
+    ports:
+      - "${CITOID_PORT}:1970"


### PR DESCRIPTION
Features:
- Adds "CITOID_URL" environment parameter to define used CITOID server
- Adds a citoid instance to the local docker-compose.yml

How to test:
- Checkout to this branch
- docker compose up
- Test citoid functionality

Fix #3