### PR TITLE
Enable canonical URLs, add check for ENV variable

### DIFF
--- a/conf/LocalSettings/core/Paths.php
+++ b/conf/LocalSettings/core/Paths.php
@@ -15,7 +15,12 @@ $wgUsePathInfo = true;
 
 ## The protocol and server name to use in fully-qualified URLs
 $wgServer = getenv('FULL_URL');
-$wgCanonicalServer = getenv('CANONICAL_URL');
+
+# Enable canonical link, use "CANONICAL_URL" env parameter if provided
+$wgEnableCanonicalServerLink = true;
+if(getenv("CANONICAL_URL")) {
+    $wgCanonicalServer = getenv('CANONICAL_URL');
+}
 
 ## The URL path to static resources (images, scripts, etc.)
 $wgResourceBasePath = $wgScriptPath;


### PR DESCRIPTION
Features:
- Enables canonical URLs
- Adds additional check to allow for CANONICAL_URL env existance

How to test:
- Start instance
- Open a page
- Check head for <link rel="canonical"> entry
- Change ENV variable
- Verify URL uses that

Related to #13