### PR TITLE
Add ArchiveLinkHelper extension for automatic archive.org links

### DIFF
--- a/conf/LocalSettings.php
+++ b/conf/LocalSettings.php
@@ -87,6 +87,7 @@ require_once './LocalSettings/extensions/CodeEditor.php';
 require_once './LocalSettings/extensions/NewUserMessage.php';
 require_once './LocalSettings/extensions/TwoColConflict.php';
 require_once './LocalSettings/extensions/CodeMirror.php';
+require_once './LocalSettings/extensions/ArchiveLinkHelper.php';
 
 
 # Customizations

--- a/conf/LocalSettings/extensions/ArchiveLinkHelper.php
+++ b/conf/LocalSettings/extensions/ArchiveLinkHelper.php
@@ -1,0 +1,3 @@
+<?php
+
+wfLoadExtension( 'ArchiveLinkHelper' );

--- a/extensions/ArchiveLinksHelper/README.md
+++ b/extensions/ArchiveLinksHelper/README.md
@@ -1,0 +1,19 @@
+# ArchiveLinkHelper
+
+A MediaWiki extension that helps users create and insert archive.org links alongside external URLs to preserve evidence.
+
+## Features
+
+- **Editor toolbar button**: Check/create archives for URLs while editing
+- **View mode indicators**: Shows `[archived]` or `[archive this]` next to external links
+
+## Installation
+
+Add to `LocalSettings.php`:
+```php
+wfLoadExtension( 'ArchiveLinkHelper' );
+```
+
+## License
+
+GPL-3.0-or-later

--- a/extensions/ArchiveLinksHelper/extension.json
+++ b/extensions/ArchiveLinksHelper/extension.json
@@ -1,0 +1,72 @@
+{
+	"name": "ArchiveLinkHelper",
+	"version": "1.0.0",
+	"author": [
+		"Consumer Rights Wiki Contributors"
+	],
+	"url": "https://github.com/FULU-Foundation/crw",
+	"descriptionmsg": "archivelinkhelper-desc",
+	"license-name": "GPL-3.0-or-later",
+	"type": "other",
+	"requires": {
+		"MediaWiki": ">= 1.39.0"
+	},
+	"MessagesDirs": {
+		"ArchiveLinkHelper": [
+			"i18n"
+		]
+	},
+	"ResourceModules": {
+		"ext.archiveLinkHelper": {
+			"scripts": [
+				"resources/ext.archivelinkhelper.js"
+			],
+			"dependencies": [
+				"mediawiki.api",
+				"mediawiki.util",
+				"mediawiki.notify",
+				"jquery.ui"
+			],
+			"messages": [
+				"archivelinkhelper-button-label",
+				"archivelinkhelper-checking",
+				"archivelinkhelper-found",
+				"archivelinkhelper-not-found",
+				"archivelinkhelper-dialog-title",
+				"archivelinkhelper-dialog-no-archive",
+				"archivelinkhelper-dialog-create",
+				"archivelinkhelper-archive-now",
+				"archivelinkhelper-insert-placeholder",
+				"archivelinkhelper-cancel",
+				"archivelinkhelper-sending",
+				"archivelinkhelper-waiting",
+				"archivelinkhelper-success",
+				"archivelinkhelper-timeout",
+				"archivelinkhelper-prompt",
+				"archivelinkhelper-invalid-url"
+			]
+		},
+		"ext.archiveLinkHelper.view": {
+			"scripts": [
+				"resources/ext.archivelinkhelper.view.js"
+			],
+			"styles": [
+				"resources/ext.archivelinkhelper.view.css"
+			],
+			"dependencies": [
+				"mediawiki.util"
+			]
+		}
+	},
+	"ResourceFileModulePaths": {
+		"localBasePath": "",
+		"remoteExtPath": "ArchiveLinkHelper"
+	},
+	"Hooks": {
+		"BeforePageDisplay": "ArchiveLinkHelperHooks::onBeforePageDisplay"
+	},
+	"AutoloadClasses": {
+		"ArchiveLinkHelperHooks": "includes/ArchiveLinkHelperHooks.php"
+	},
+	"manifest_version": 2
+}

--- a/extensions/ArchiveLinksHelper/i18n/en.json
+++ b/extensions/ArchiveLinksHelper/i18n/en.json
@@ -1,0 +1,24 @@
+{
+	"@metadata": {
+		"authors": [
+			"Consumer Rights Wiki Contributors"
+		]
+	},
+	"archivelinkhelper-desc": "Helps users create and insert archive.org links alongside external URLs to preserve evidence",
+	"archivelinkhelper-button-label": "Archive Link",
+	"archivelinkhelper-checking": "Checking archive.org for:",
+	"archivelinkhelper-found": "Archive found! Link inserted.",
+	"archivelinkhelper-not-found": "No archive found for this URL.",
+	"archivelinkhelper-dialog-title": "Create Archive Link",
+	"archivelinkhelper-dialog-no-archive": "No archive found for this URL.",
+	"archivelinkhelper-dialog-create": "Would you like to create one?",
+	"archivelinkhelper-archive-now": "Archive Now",
+	"archivelinkhelper-insert-placeholder": "Insert Placeholder",
+	"archivelinkhelper-cancel": "Cancel",
+	"archivelinkhelper-sending": "Sending archive request...",
+	"archivelinkhelper-waiting": "Waiting for archive.org to process...",
+	"archivelinkhelper-success": "Archive created successfully!",
+	"archivelinkhelper-timeout": "Archive is taking longer than expected. You can try again later or insert a placeholder link.",
+	"archivelinkhelper-prompt": "Enter a URL to archive and link:",
+	"archivelinkhelper-invalid-url": "Please enter a valid URL starting with http:// or https://"
+}

--- a/extensions/ArchiveLinksHelper/includes/ArchiveLinkHelperHooks.php
+++ b/extensions/ArchiveLinksHelper/includes/ArchiveLinkHelperHooks.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Hooks for ArchiveLinkHelper extension
+ *
+ * @file
+ * @ingroup Extensions
+ * @license GPL-3.0-or-later
+ */
+
+class ArchiveLinkHelperHooks {
+
+	/**
+	 * Add modules to page output
+	 *
+	 * @param OutputPage $out
+	 * @param Skin $skin
+	 */
+	public static function onBeforePageDisplay( $out, $skin ) {
+		$action = $out->getRequest()->getVal( 'action', 'view' );
+		
+		// Load editor module when editing
+		if ( in_array( $action, [ 'edit', 'submit' ] ) ) {
+			$out->addModules( 'ext.archiveLinkHelper' );
+		}
+		
+		// Load view module when viewing pages (adds archive indicators to links)
+		if ( $action === 'view' ) {
+			$out->addModules( 'ext.archiveLinkHelper.view' );
+		}
+	}
+}

--- a/extensions/ArchiveLinksHelper/resources/ext.archivelinkhelper.js
+++ b/extensions/ArchiveLinksHelper/resources/ext.archivelinkhelper.js
@@ -1,0 +1,249 @@
+/**
+ * ArchiveLinkHelper - Editor Integration
+ *
+ * @license GPL-3.0-or-later
+ */
+
+( function () {
+	'use strict';
+
+	var ARCHIVE_ORG_AVAILABLE_API = 'https://archive.org/wayback/available';
+	var ARCHIVE_ORG_SAVE_URL = 'https://web.archive.org/save/';
+	var ARCHIVE_ORG_WEB_URL = 'https://web.archive.org/web/';
+
+	var POLL_INTERVAL_MS = 5000;
+	var MAX_POLL_ATTEMPTS = 24;
+
+	function checkArchiveAvailability( url ) {
+		var deferred = $.Deferred();
+
+		$.ajax( {
+			url: ARCHIVE_ORG_AVAILABLE_API,
+			data: { url: url },
+			dataType: 'jsonp',
+			timeout: 10000
+		} ).done( function ( data ) {
+			if ( data && data.archived_snapshots && data.archived_snapshots.closest ) {
+				deferred.resolve( data.archived_snapshots.closest );
+			} else {
+				deferred.resolve( null );
+			}
+		} ).fail( function () {
+			deferred.resolve( null );
+		} );
+
+		return deferred.promise();
+	}
+
+	function triggerArchiveSaveFetch( url ) {
+		if ( window.fetch ) {
+			return fetch( ARCHIVE_ORG_SAVE_URL, {
+				method: 'POST',
+				mode: 'no-cors',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded'
+				},
+				body: 'url=' + encodeURIComponent( url )
+			} ).catch( function () {} );
+		}
+		return $.Deferred().resolve().promise();
+	}
+
+	function formatWikiLink( originalUrl, archiveUrl, linkText ) {
+		if ( linkText ) {
+			return '[' + originalUrl + ' ' + linkText + '] ([' + archiveUrl + ' archived])';
+		}
+		return originalUrl + ' ([' + archiveUrl + ' archived])';
+	}
+
+	function extractUrls( text ) {
+		var urlRegex = /https?:\/\/[^\s\]\[<>]+/g;
+		return text.match( urlRegex ) || [];
+	}
+
+	function insertArchiveLink( $textarea, originalUrl, archiveUrl, selection ) {
+		var linkText = '';
+		var replacement;
+
+		var wikiLinkMatch = selection.match( /\[https?:\/\/[^\s\]]+ ([^\]]+)\]/ );
+		if ( wikiLinkMatch ) {
+			linkText = wikiLinkMatch[ 1 ];
+		}
+
+		replacement = formatWikiLink( originalUrl, archiveUrl, linkText );
+
+		if ( selection ) {
+			$textarea.textSelection( 'replaceSelection', replacement );
+		} else {
+			$textarea.textSelection( 'encapsulateSelection', {
+				pre: replacement
+			} );
+		}
+	}
+
+	function showArchiveDialog( url, $textarea, selection ) {
+		var $dialog = $( '<div>' )
+			.attr( 'id', 'archive-link-dialog' )
+			.append( $( '<p>' ).text( mw.msg( 'archivelinkhelper-dialog-no-archive' ) ) )
+			.append( $( '<p>' ).text( mw.msg( 'archivelinkhelper-dialog-create' ) ) );
+
+		var $status = $( '<p>' )
+			.attr( 'id', 'archive-status' )
+			.css( 'font-style', 'italic' );
+
+		var $progressBar = $( '<div>' ).css( {
+			width: '100%',
+			height: '8px',
+			background: '#eee',
+			borderRadius: '4px',
+			marginTop: '10px',
+			display: 'none'
+		} );
+
+		var $progressFill = $( '<div>' ).css( {
+			width: '0%',
+			height: '100%',
+			background: '#4CAF50',
+			borderRadius: '4px',
+			transition: 'width 0.3s'
+		} );
+
+		$progressBar.append( $progressFill );
+		$dialog.append( $status ).append( $progressBar );
+
+		var isArchiving = false;
+		var pollCount = 0;
+
+		function startArchiving() {
+			if ( isArchiving ) {
+				return;
+			}
+			isArchiving = true;
+			pollCount = 0;
+
+			$status.text( mw.msg( 'archivelinkhelper-sending' ) );
+			$progressBar.show();
+			$progressFill.css( 'width', '5%' );
+
+			triggerArchiveSaveFetch( url ).then( function () {
+				$status.text( mw.msg( 'archivelinkhelper-waiting' ) );
+				$progressFill.css( 'width', '15%' );
+				pollForNewArchive();
+			} );
+		}
+
+		function pollForNewArchive() {
+			pollCount++;
+			var progress = Math.min( 15 + ( pollCount * 3.5 ), 95 );
+			$progressFill.css( 'width', progress + '%' );
+
+			checkArchiveAvailability( url ).then( function ( snapshot ) {
+				if ( snapshot && snapshot.available ) {
+					$progressFill.css( 'width', '100%' );
+					$status.text( mw.msg( 'archivelinkhelper-success' ) );
+
+					setTimeout( function () {
+						insertArchiveLink( $textarea, url, snapshot.url, selection );
+						mw.notify( mw.msg( 'archivelinkhelper-success' ), { type: 'success' } );
+						$dialog.dialog( 'close' );
+					}, 500 );
+				} else if ( pollCount < MAX_POLL_ATTEMPTS ) {
+					$status.text( mw.msg( 'archivelinkhelper-waiting' ) +
+						' (' + pollCount + '/' + MAX_POLL_ATTEMPTS + ')' );
+					setTimeout( pollForNewArchive, POLL_INTERVAL_MS );
+				} else {
+					$status.text( mw.msg( 'archivelinkhelper-timeout' ) );
+					$progressBar.hide();
+					isArchiving = false;
+				}
+			} );
+		}
+
+		$dialog.dialog( {
+			title: mw.msg( 'archivelinkhelper-dialog-title' ),
+			width: 450,
+			modal: true,
+			buttons: [
+				{
+					text: mw.msg( 'archivelinkhelper-archive-now' ),
+					click: function () {
+						startArchiving();
+					}
+				},
+				{
+					text: mw.msg( 'archivelinkhelper-insert-placeholder' ),
+					click: function () {
+						var placeholder = ARCHIVE_ORG_WEB_URL + '*/' + url;
+						insertArchiveLink( $textarea, url, placeholder, selection );
+						mw.notify( mw.msg( 'archivelinkhelper-found' ), { type: 'info' } );
+						$dialog.dialog( 'close' );
+					}
+				},
+				{
+					text: mw.msg( 'archivelinkhelper-cancel' ),
+					click: function () {
+						$dialog.dialog( 'close' );
+					}
+				}
+			],
+			close: function () {
+				$( this ).dialog( 'destroy' ).remove();
+			}
+		} );
+	}
+
+	function handleArchiveLinkAction( context ) {
+		var $textarea = context.$textarea;
+		var selection = $textarea.textSelection( 'getSelection' );
+		var urls = extractUrls( selection );
+
+		if ( urls.length === 0 ) {
+			var inputUrl = prompt( mw.msg( 'archivelinkhelper-prompt' ) );
+			if ( inputUrl && inputUrl.match( /^https?:\/\// ) ) {
+				urls = [ inputUrl ];
+			} else if ( inputUrl ) {
+				mw.notify( mw.msg( 'archivelinkhelper-invalid-url' ), { type: 'error' } );
+				return;
+			} else {
+				return;
+			}
+		}
+
+		var url = urls[ 0 ];
+		mw.notify( mw.msg( 'archivelinkhelper-checking' ) + ' ' + url, { type: 'info' } );
+
+		checkArchiveAvailability( url ).then( function ( snapshot ) {
+			if ( snapshot && snapshot.available ) {
+				insertArchiveLink( $textarea, url, snapshot.url, selection );
+				mw.notify( mw.msg( 'archivelinkhelper-found' ), { type: 'success' } );
+			} else {
+				showArchiveDialog( url, $textarea, selection );
+			}
+		} );
+	}
+
+	function addToolbarButton() {
+		$( '#wpTextbox1' ).wikiEditor( 'addToToolbar', {
+			section: 'main',
+			group: 'insert',
+			tools: {
+				archiveLink: {
+					label: mw.msg( 'archivelinkhelper-button-label' ),
+					type: 'button',
+					oouiIcon: 'clock',
+					action: {
+						type: 'callback',
+						execute: function ( context ) {
+							handleArchiveLinkAction( context );
+						}
+					}
+				}
+			}
+		} );
+	}
+
+	mw.hook( 'wikiEditor.toolbarReady' ).add( function () {
+		addToolbarButton();
+	} );
+
+}() );

--- a/extensions/ArchiveLinksHelper/resources/ext.archivelinkhelper.view.css
+++ b/extensions/ArchiveLinksHelper/resources/ext.archivelinkhelper.view.css
@@ -1,0 +1,41 @@
+/**
+ * ArchiveLinkHelper - View Mode Styles
+ *
+ * @license GPL-3.0-or-later
+ */
+
+.archive-indicator {
+	font-size: 0.85em;
+	margin-left: 3px;
+}
+
+.archive-link {
+	text-decoration: none;
+}
+
+.archive-link-exists {
+	color: #228b22;
+}
+
+.archive-link-exists:hover {
+	color: #1a6b1a;
+	text-decoration: underline;
+}
+
+.archive-link-missing {
+	color: #cc7000;
+}
+
+.archive-link-missing:hover {
+	color: #995400;
+	text-decoration: underline;
+}
+
+.archive-link-pending {
+	color: #666;
+	cursor: wait;
+}
+
+.archive-link-timeout {
+	color: #999;
+}

--- a/extensions/ArchiveLinksHelper/resources/ext.archivelinkhelper.view.js
+++ b/extensions/ArchiveLinksHelper/resources/ext.archivelinkhelper.view.js
@@ -1,0 +1,141 @@
+/**
+ * ArchiveLinkHelper - View Mode Integration
+ *
+ * @license GPL-3.0-or-later
+ */
+
+( function () {
+	'use strict';
+
+	var ARCHIVE_ORG_AVAILABLE_API = 'https://archive.org/wayback/available';
+	var ARCHIVE_ORG_SAVE_URL = 'https://web.archive.org/save/';
+
+	var POLL_INTERVAL_MS = 5000;
+	var MAX_POLL_ATTEMPTS = 24;
+
+	function checkArchiveAvailability( url ) {
+		var deferred = $.Deferred();
+
+		$.ajax( {
+			url: ARCHIVE_ORG_AVAILABLE_API,
+			data: { url: url },
+			dataType: 'jsonp',
+			timeout: 10000
+		} ).done( function ( data ) {
+			if ( data && data.archived_snapshots && data.archived_snapshots.closest ) {
+				deferred.resolve( data.archived_snapshots.closest );
+			} else {
+				deferred.resolve( null );
+			}
+		} ).fail( function () {
+			deferred.resolve( null );
+		} );
+
+		return deferred.promise();
+	}
+
+	function triggerArchiveSave( url ) {
+		if ( window.fetch ) {
+			return fetch( ARCHIVE_ORG_SAVE_URL, {
+				method: 'POST',
+				mode: 'no-cors',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded'
+				},
+				body: 'url=' + encodeURIComponent( url )
+			} ).catch( function () {} );
+		}
+		return $.Deferred().resolve().promise();
+	}
+
+	function addArchiveIndicators( $content ) {
+		var $externalLinks = $content.find( 'a.external' );
+
+		$externalLinks.each( function () {
+			var $link = $( this );
+			var url = $link.attr( 'href' );
+
+			if ( $link.data( 'archive-checked' ) ||
+				url.indexOf( 'archive.org' ) !== -1 ||
+				url.indexOf( 'web.archive.org' ) !== -1 ) {
+				return;
+			}
+
+			$link.data( 'archive-checked', true );
+
+			var $indicator = $( '<span>' )
+				.addClass( 'archive-indicator' )
+				.text( ' ⏳' );
+
+			$link.after( $indicator );
+
+			checkArchiveAvailability( url ).then( function ( snapshot ) {
+				if ( snapshot && snapshot.available ) {
+					$indicator
+						.empty()
+						.append(
+							$( '<a>' )
+								.attr( 'href', snapshot.url )
+								.attr( 'title', 'Archived: ' + snapshot.timestamp )
+								.addClass( 'archive-link archive-link-exists' )
+								.text( ' [archived]' )
+						);
+				} else {
+					var $archiveLink = $( '<a>' )
+						.attr( 'href', '#' )
+						.attr( 'title', 'No archive found - click to create one' )
+						.addClass( 'archive-link archive-link-missing' )
+						.text( ' [archive this]' )
+						.on( 'click', function ( e ) {
+							e.preventDefault();
+							var $this = $( this );
+
+							if ( $this.data( 'archiving' ) ) {
+								return;
+							}
+
+							$this.data( 'archiving', true );
+							$this.text( ' [archiving...]' )
+								.removeClass( 'archive-link-missing' )
+								.addClass( 'archive-link-pending' );
+
+							triggerArchiveSave( url ).then( function () {
+								var attempts = 0;
+								var checkInterval = setInterval( function () {
+									attempts++;
+									checkArchiveAvailability( url ).then( function ( newSnapshot ) {
+										if ( newSnapshot && newSnapshot.available ) {
+											clearInterval( checkInterval );
+											$this
+												.attr( 'href', newSnapshot.url )
+												.off( 'click' )
+												.removeClass( 'archive-link-pending' )
+												.addClass( 'archive-link-exists' )
+												.text( ' [archived]' )
+												.data( 'archiving', false );
+										} else if ( attempts >= MAX_POLL_ATTEMPTS ) {
+											clearInterval( checkInterval );
+											$this
+												.removeClass( 'archive-link-pending' )
+												.addClass( 'archive-link-timeout' )
+												.text( ' [archive pending]' )
+												.data( 'archiving', false );
+										}
+									} );
+								}, POLL_INTERVAL_MS );
+							} );
+						} );
+
+					$indicator.empty().append( $archiveLink );
+				}
+			} );
+		} );
+	}
+
+	mw.hook( 'wikipage.content' ).add( function ( $content ) {
+		if ( mw.config.get( 'wgAction' ) === 'view' ) {
+			addArchiveIndicators( $content );
+		}
+	} );
+
+}() );


### PR DESCRIPTION
   - Adds toolbar button in editor to check/create archive links
   - Shows archive status indicators on external links when viewing pages
   - Uses client-side JSONP for availability checks
   - Triggers archiving via fetch no-cors POST request