### PR TITLE
Remove build-deploy target from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,5 @@ run:
 run-bg:
 	docker compose up --build -d
 
-build-deploy:
-	docker build . -t registry.digitalocean.com/crw-wiki/wiki:latest
-	docker push registry.digitalocean.com/crw-wiki/wiki:latest
-
 bash:
 	docker compose exec -i crw-local bash


### PR DESCRIPTION
Removed build and deploy commands from Makefile. (Redundant DO commands)