### PR TITLE
SEO: Add namespace indexing policies, auto meta descriptions, and OpenGraph fixes

### DIFF
--- a/conf/LocalSettings.php
+++ b/conf/LocalSettings.php
@@ -98,6 +98,7 @@ require_once './LocalSettings/extensions/SearchDigest.php';
 
 # Customizations
 require_once './LocalSettings/customizations/Footer.php';
+require_once './LocalSettings/customizations/SEO.php';
 
 # Groups
 require_once './LocalSettings/core/Groups.php';

--- a/conf/LocalSettings/core/Security.php
+++ b/conf/LocalSettings/core/Security.php
@@ -6,3 +6,23 @@ $wgHiddenPrefs[] = 'language';
 
 # Hides software version information from public view
 $wgHideSoftwareVersion = true;
+
+# Noindex non-content namespaces to prevent Google's Helpful Content
+# classifier from suppressing site-wide rankings due to high junk-to-content ratio.
+# Uses noindex,follow so link equity still flows through these pages.
+# NS_CATEGORY deliberately excluded — thin categories handled conditionally in SEO.php.
+$wgNamespaceRobotPolicies = [
+    NS_TALK            => 'noindex,follow',
+    NS_USER            => 'noindex,follow',
+    NS_USER_TALK       => 'noindex,follow',
+    NS_PROJECT         => 'noindex,follow',
+    NS_PROJECT_TALK    => 'noindex,follow',
+    NS_FILE_TALK       => 'noindex,follow',
+    NS_HELP            => 'noindex,follow',
+    NS_HELP_TALK       => 'noindex,follow',
+    NS_TEMPLATE_TALK   => 'noindex,follow',
+    NS_CATEGORY_TALK   => 'noindex,follow',
+    NS_MEDIAWIKI_TALK  => 'noindex,follow',
+    3004               => 'noindex,follow',  // Projects
+    3005               => 'noindex,follow',  // Projects_talk
+];

--- a/conf/LocalSettings/customizations/SEO.php
+++ b/conf/LocalSettings/customizations/SEO.php
@@ -1,0 +1,100 @@
+<?php
+
+# SEO-related hooks for indexation control and OpenGraph completeness.
+# This file contains BeforePageDisplay hooks that improve search engine
+# and social media handling of wiki pages.
+
+use MediaWiki\Output\OutputPage;
+
+# Add og:type meta tag to satisfy OpenGraph protocol requirements.
+# WikiSEO handles og:title, og:description, og:image but omits og:type.
+# Main page and non-article pages get "website"; articles get "article".
+$wgHooks['BeforePageDisplay'][] = function ( OutputPage $out, Skin $skin ) {
+    $title = $out->getTitle();
+    if ( $title->isSpecialPage() ) {
+        return;
+    }
+    $ogType = ( $title->getNamespace() === NS_MAIN && !$title->isMainPage() ) ? 'article' : 'website';
+    $out->addHeadItem( 'og:type', '<meta property="og:type" content="' . htmlspecialchars( $ogType ) . '" />' );
+};
+
+# Auto-populate meta description from Cargo IncidentCargo.Description field
+# when no manual {{#seo:description=...}} exists on the page.
+# Priority: manual {{#seo:}} > Cargo Description > WikiSEO auto-description.
+# Only queries Cargo for main-namespace content pages to minimize DB load.
+$wgHooks['BeforePageDisplay'][] = function ( OutputPage $out, Skin $skin ) {
+    $title = $out->getTitle();
+
+    // Only main namespace, non-main-page, non-special
+    if ( $title->getNamespace() !== NS_MAIN || $title->isMainPage() || $title->isSpecialPage() ) {
+        return;
+    }
+
+    // Check if a description meta tag was already set (by WikiSEO's {{#seo:}} tag)
+    $existingMeta = $out->getMetaTags();
+    foreach ( $existingMeta as $tag ) {
+        if ( isset( $tag[0] ) && $tag[0] === 'description' && !empty( $tag[1] ) && $tag[1] !== '.' ) {
+            return; // Manual description exists, don't override
+        }
+    }
+
+    // Query Cargo for the Description field
+    if ( !class_exists( 'CargoUtils' ) ) {
+        return;
+    }
+
+    try {
+        $dbr = CargoUtils::getDB();
+        $res = $dbr->select(
+            'IncidentCargo',
+            [ 'Description' ],
+            [ '_pageName' => $title->getText() ],
+            __METHOD__
+        );
+        $row = $res->fetchObject();
+        if ( $row && !empty( $row->Description ) ) {
+            $description = trim( $row->Description );
+            // Truncate to 160 characters at last complete word
+            if ( strlen( $description ) > 160 ) {
+                $description = substr( $description, 0, 157 );
+                $description = substr( $description, 0, strrpos( $description, ' ' ) ) . '...';
+            }
+            $out->addMeta( 'description', $description );
+            $out->addHeadItem(
+                'og:description:cargo',
+                '<meta property="og:description" content="' . htmlspecialchars( $description ) . '" />'
+            );
+        }
+    } catch ( Exception $e ) {
+        // Silently fail — Cargo table may not exist yet or may have been rebuilt
+        wfDebugLog( 'SEO', 'Cargo description lookup failed: ' . $e->getMessage() );
+    }
+};
+
+# Conditionally noindex thin categories (fewer than 5 members).
+# Prevents empty/near-empty category listing pages from diluting site quality signals.
+# Categories automatically become indexable once they reach 5 members.
+$wgHooks['BeforePageDisplay'][] = function ( OutputPage $out, Skin $skin ) {
+    $title = $out->getTitle();
+    if ( $title->getNamespace() !== NS_CATEGORY ) {
+        return;
+    }
+    $category = Category::newFromTitle( $title );
+    if ( $category && $category->getMemberCount() < 5 ) {
+        $out->setRobotPolicy( 'noindex,follow' );
+    }
+};
+
+# Conditionally noindex stub articles (fewer than 2,000 bytes of wikitext).
+# Thin stubs trigger Google's Helpful Content classifier as low-quality signals.
+# Uses $title->getLength() which reads cached page_len — no content loading required.
+# Articles automatically become indexable as the community expands them past 2,000 bytes.
+$wgHooks['BeforePageDisplay'][] = function ( OutputPage $out, Skin $skin ) {
+    $title = $out->getTitle();
+    if ( $title->getNamespace() !== NS_MAIN || $title->isMainPage() ) {
+        return;
+    }
+    if ( $title->getLength() < 2000 ) {
+        $out->setRobotPolicy( 'noindex,follow' );
+    }
+};

--- a/conf/LocalSettings/customizations/SEO.php
+++ b/conf/LocalSettings/customizations/SEO.php
@@ -4,6 +4,7 @@
 # This file contains BeforePageDisplay hooks that improve search engine
 # and social media handling of wiki pages.
 
+use MediaWiki\Category\Category;
 use MediaWiki\Output\OutputPage;
 
 # Add og:type meta tag to satisfy OpenGraph protocol requirements.

--- a/conf/LocalSettings/extensions/WikiSEO.php
+++ b/conf/LocalSettings/extensions/WikiSEO.php
@@ -5,3 +5,8 @@ wfLoadExtension( 'WikiSEO' );
 $wgWikiSeoEnableAutoDescription = true;
 $wgWikiSeoTryCleanAutoDescription = true;
 $wgWikiSeoDefaultLanguage = "en-us";
+
+# Default social preview image for OpenGraph (og:image) when a page has no specific image.
+# Ideal: 1200x630px branded image. Using site logo as interim until a proper social image is uploaded.
+# TODO: Replace with a dedicated 1200x630 social preview image once created and uploaded.
+$wgWikiSeoDefaultImage = '/images/logo/new_fixed_logo.png';


### PR DESCRIPTION
## Summary

Bundles six repo-side SEO fixes from the SEO recovery campaign to address two critical issues:
1. **3.7:1 junk-to-content indexing ratio** — ~4,673 non-content pages (Talk, User, Help, etc.) are currently indexable, triggering Google's Helpful Content site-wide ranking suppression
2. **Incomplete OpenGraph metadata** — missing og:type, no fallback og:image, and 434 articles without meta descriptions

### Changes

- **R1: Namespace Robot Policies** — `$wgNamespaceRobotPolicies` noindexes 13 non-content namespaces in `Security.php`
- **R2: WikiSEO Default Image** — `$wgWikiSeoDefaultImage` provides fallback social preview image in `WikiSEO.php`
- **R3: og:type Meta Tag** — `BeforePageDisplay` hook adds required OpenGraph og:type in new `SEO.php`
- **R4: Cargo Auto Description** — `BeforePageDisplay` hook extracts `IncidentCargo.Description` as meta description fallback
- **R5: Thin Category Noindex** — Conditionally noindexes categories with <5 members (self-healing)
- **R6: Stub Article Noindex** — Conditionally noindexes articles under 2,000 bytes (self-healing)

### Files Changed

| File | Change |
|------|--------|
| `conf/LocalSettings/core/Security.php` | Added `$wgNamespaceRobotPolicies` with 13 namespace entries |
| `conf/LocalSettings/extensions/WikiSEO.php` | Added `$wgWikiSeoDefaultImage` |
| `conf/LocalSettings/customizations/SEO.php` | **New file** — 4 `BeforePageDisplay` hooks |
| `conf/LocalSettings.php` | Registered `SEO.php` in Customizations section |

### Technical Details

- All `noindex` directives use `noindex,follow` to preserve link equity flow
- Cargo description hook has `try/catch` for graceful failure if table doesn't exist
- Stub detection uses `$title->getLength()` (cached `page_len`) — no deprecated `WikiPage::factory()`
- og:type uses `addHeadItem()` for proper `property=` OpenGraph attribute (not `addMeta()` which generates `name=`)
- All MW APIs used are stable since MW 1.25 or earlier

### Post-Deploy

After merging and deploying the new image:
- Run `make update` to ensure database schema is current
- Spot-check robot meta tags: visit a Talk page, User page, thin category, and stub article — verify `<meta name="robots" content="noindex,follow">` in page source
- Monitor Google Search Console for indexing changes over 2–4 weeks

### Risk

**Low-Medium.** All noindex changes are reversible by reverting the commit. The Cargo description hook has a try/catch for graceful failure. Stub noindex (R6) will remove the most pages from Google's index but is self-healing as articles grow past 2,000 bytes.

## Test plan

- [ ] Docker image builds successfully (CI validates this)
- [ ] PHP syntax clean for all modified files
- [ ] No deprecated MW APIs used
- [ ] No secrets or Claude-related files included