### PR TITLE
SEO recovery: indexation hardening, OpenGraph, robots.txt, and domain root routing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ COPY ./skins/ /var/www/html/skins/
 COPY ./conf/LocalSettings.php /var/www/html/LocalSettings.php
 COPY ./conf/LocalSettings /var/www/html/LocalSettings
 
+# robots.txt — served directly by nginx, blocks crawling of MW infrastructure URLs
+COPY ./robots.txt /var/www/html/robots.txt
+
 # Copy PHP-FPM pool conf
 COPY ./conf/www.conf /usr/local/etc/php-fpm.d/www.conf
 

--- a/conf/LocalSettings.php
+++ b/conf/LocalSettings.php
@@ -98,6 +98,7 @@ require_once './LocalSettings/extensions/SearchDigest.php';
 
 # Customizations
 require_once './LocalSettings/customizations/Footer.php';
+require_once './LocalSettings/customizations/SEO.php';
 
 # Groups
 require_once './LocalSettings/core/Groups.php';

--- a/conf/LocalSettings/core/Debug.php
+++ b/conf/LocalSettings/core/Debug.php
@@ -3,6 +3,10 @@
 # Memory Limit
 ini_set('memory_limit', '512M'); // Increase memory limit to handle large operations, such as processing large images.
 
+# Suppress PHP deprecation notices — MW 1.44 core triggers E_DEPRECATED warnings
+# from internal skin methods that are not actionable by site operators.
+error_reporting( E_ALL & ~E_DEPRECATED & ~E_STRICT );
+ini_set( 'display_errors', 0 );
 
 # Exception and Error Details
 $wgShowExceptionDetails = false;    // Display detailed exception information for easier troubleshooting.

--- a/conf/LocalSettings/core/Namespaces.php
+++ b/conf/LocalSettings/core/Namespaces.php
@@ -16,3 +16,8 @@ define("NS_PROJECTS_TALK", 3005);
 
 $wgExtraNamespaces[NS_PROJECTS] = "Projects";
 $wgExtraNamespaces[NS_PROJECTS_TALK] = "Projects_talk";
+
+# Restrict sitemap generation to main namespace (articles) only.
+# Non-content namespaces are noindexed via $wgNamespaceRobotPolicies in Security.php,
+# so including them in the sitemap would send contradictory signals to search engines.
+$wgSitemapNamespaces = [ 0 ];

--- a/conf/LocalSettings/core/Paths.php
+++ b/conf/LocalSettings/core/Paths.php
@@ -26,3 +26,8 @@ if(getenv("CANONICAL_URL")) {
 $wgResourceBasePath = $wgScriptPath;
 
 $wgUploadDirectory = "/var/www/html/images/";
+
+# Serve Main Page directly at the domain root (/) instead of redirecting
+# to /w/Main_Page. Eliminates the double 301 redirect chain that wastes
+# crawl budget and dilutes link equity on a new domain.
+$wgMainPageIsDomainRoot = true;

--- a/conf/LocalSettings/core/Security.php
+++ b/conf/LocalSettings/core/Security.php
@@ -6,3 +6,23 @@ $wgHiddenPrefs[] = 'language';
 
 # Hides software version information from public view
 $wgHideSoftwareVersion = true;
+
+# Noindex non-content namespaces to prevent Google's Helpful Content
+# classifier from suppressing site-wide rankings due to high junk-to-content ratio.
+# Uses noindex,follow so link equity still flows through these pages.
+# NS_CATEGORY deliberately excluded — thin categories handled conditionally in SEO.php.
+$wgNamespaceRobotPolicies = [
+    NS_TALK            => 'noindex,follow',
+    NS_USER            => 'noindex,follow',
+    NS_USER_TALK       => 'noindex,follow',
+    NS_PROJECT         => 'noindex,follow',
+    NS_PROJECT_TALK    => 'noindex,follow',
+    NS_FILE_TALK       => 'noindex,follow',
+    NS_HELP            => 'noindex,follow',
+    NS_HELP_TALK       => 'noindex,follow',
+    NS_TEMPLATE_TALK   => 'noindex,follow',
+    NS_CATEGORY_TALK   => 'noindex,follow',
+    NS_MEDIAWIKI_TALK  => 'noindex,follow',
+    3004               => 'noindex,follow',  // Projects
+    3005               => 'noindex,follow',  // Projects_talk
+];

--- a/conf/LocalSettings/customizations/SEO.php
+++ b/conf/LocalSettings/customizations/SEO.php
@@ -1,0 +1,101 @@
+<?php
+
+# SEO-related hooks for indexation control and OpenGraph completeness.
+# This file contains BeforePageDisplay hooks that improve search engine
+# and social media handling of wiki pages.
+
+use MediaWiki\Category\Category;
+use MediaWiki\Output\OutputPage;
+
+# Add og:type meta tag to satisfy OpenGraph protocol requirements.
+# WikiSEO handles og:title, og:description, og:image but omits og:type.
+# Main page and non-article pages get "website"; articles get "article".
+$wgHooks['BeforePageDisplay'][] = function ( OutputPage $out, Skin $skin ) {
+    $title = $out->getTitle();
+    if ( $title->isSpecialPage() ) {
+        return;
+    }
+    $ogType = ( $title->getNamespace() === NS_MAIN && !$title->isMainPage() ) ? 'article' : 'website';
+    $out->addHeadItem( 'og:type', '<meta property="og:type" content="' . htmlspecialchars( $ogType ) . '" />' );
+};
+
+# Auto-populate meta description from Cargo IncidentCargo.Description field
+# when no manual {{#seo:description=...}} exists on the page.
+# Priority: manual {{#seo:}} > Cargo Description > WikiSEO auto-description.
+# Only queries Cargo for main-namespace content pages to minimize DB load.
+$wgHooks['BeforePageDisplay'][] = function ( OutputPage $out, Skin $skin ) {
+    $title = $out->getTitle();
+
+    // Only main namespace, non-main-page, non-special
+    if ( $title->getNamespace() !== NS_MAIN || $title->isMainPage() || $title->isSpecialPage() ) {
+        return;
+    }
+
+    // Check if a description meta tag was already set (by WikiSEO's {{#seo:}} tag)
+    $existingMeta = $out->getMetaTags();
+    foreach ( $existingMeta as $tag ) {
+        if ( isset( $tag[0] ) && $tag[0] === 'description' && !empty( $tag[1] ) && $tag[1] !== '.' ) {
+            return; // Manual description exists, don't override
+        }
+    }
+
+    // Query Cargo for the Description field
+    if ( !class_exists( 'CargoUtils' ) ) {
+        return;
+    }
+
+    try {
+        $dbr = CargoUtils::getDB();
+        $res = $dbr->select(
+            'IncidentCargo',
+            [ 'Description' ],
+            [ '_pageName' => $title->getText() ],
+            __METHOD__
+        );
+        $row = $res->fetchObject();
+        if ( $row && !empty( $row->Description ) ) {
+            $description = trim( $row->Description );
+            // Truncate to 160 characters at last complete word
+            if ( strlen( $description ) > 160 ) {
+                $description = substr( $description, 0, 157 );
+                $description = substr( $description, 0, strrpos( $description, ' ' ) ) . '...';
+            }
+            $out->addMeta( 'description', $description );
+            $out->addHeadItem(
+                'og:description:cargo',
+                '<meta property="og:description" content="' . htmlspecialchars( $description ) . '" />'
+            );
+        }
+    } catch ( Exception $e ) {
+        // Silently fail — Cargo table may not exist yet or may have been rebuilt
+        wfDebugLog( 'SEO', 'Cargo description lookup failed: ' . $e->getMessage() );
+    }
+};
+
+# Conditionally noindex thin categories (fewer than 5 members).
+# Prevents empty/near-empty category listing pages from diluting site quality signals.
+# Categories automatically become indexable once they reach 5 members.
+$wgHooks['BeforePageDisplay'][] = function ( OutputPage $out, Skin $skin ) {
+    $title = $out->getTitle();
+    if ( $title->getNamespace() !== NS_CATEGORY ) {
+        return;
+    }
+    $category = Category::newFromTitle( $title );
+    if ( $category && $category->getMemberCount() < 5 ) {
+        $out->setRobotPolicy( 'noindex,follow' );
+    }
+};
+
+# Conditionally noindex stub articles (fewer than 2,000 bytes of wikitext).
+# Thin stubs trigger Google's Helpful Content classifier as low-quality signals.
+# Uses $title->getLength() which reads cached page_len — no content loading required.
+# Articles automatically become indexable as the community expands them past 2,000 bytes.
+$wgHooks['BeforePageDisplay'][] = function ( OutputPage $out, Skin $skin ) {
+    $title = $out->getTitle();
+    if ( $title->getNamespace() !== NS_MAIN || $title->isMainPage() ) {
+        return;
+    }
+    if ( $title->getLength() < 2000 ) {
+        $out->setRobotPolicy( 'noindex,follow' );
+    }
+};

--- a/conf/LocalSettings/extensions/MobileFrontend.php
+++ b/conf/LocalSettings/extensions/MobileFrontend.php
@@ -12,3 +12,7 @@ $wgMinervaPersonalMenu['base'] = true;
 $wgMinervaHistoryInPageActions['base'] = true;
 $wgMinervaOverflowInPageActions['base'] = true;
 $wgMinervaShowCategories['base'] = true;
+
+// Mobile trust signals and content parity
+$wgMinervaAlwaysShowLastModified = true;  // Show last-modified date for E-E-A-T trust
+$wgMinervaEnableSiteNotice = true;        // Show site notice on mobile for navigation links

--- a/conf/LocalSettings/extensions/WikiSEO.php
+++ b/conf/LocalSettings/extensions/WikiSEO.php
@@ -5,3 +5,8 @@ wfLoadExtension( 'WikiSEO' );
 $wgWikiSeoEnableAutoDescription = true;
 $wgWikiSeoTryCleanAutoDescription = true;
 $wgWikiSeoDefaultLanguage = "en-us";
+
+# Default social preview image for OpenGraph (og:image) when a page has no specific image.
+# Ideal: 1200x630px branded image. Using site logo as interim until a proper social image is uploaded.
+# TODO: Replace with a dedicated 1200x630 social preview image once created and uploaded.
+$wgWikiSeoDefaultImage = '/images/logo/new_fixed_logo.png';

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -31,9 +31,9 @@ server {
 		access_log off;
 	}
 	
-    # Rewrite / to point to /w/
-    location / {
-        rewrite ^/$ ./w/ permanent;
+    # Pass domain root to MediaWiki (serves Main Page via $wgMainPageIsDomainRoot)
+    location = / {
+        rewrite ^ /index.php last;
     }
 
     # Fix rest.php

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,54 @@
+# robots.txt for consumerrights.wiki
+# Blocks crawling of MediaWiki infrastructure URLs to preserve crawl budget.
+# Indexation is further controlled by $wgNamespaceRobotPolicies in Security.php.
+
+User-agent: *
+
+# Block core MediaWiki scripts and query parameters
+Disallow: /index.php
+Disallow: /api.php
+Disallow: /rest.php
+Disallow: /load.php
+Disallow: /thumb.php
+Disallow: /img_auth.php
+Disallow: /profileinfo.php
+
+# Block action, oldid, and diff parameters (wildcard supported by Google/Bing)
+Disallow: /*?*action=
+Disallow: /*?*diff=
+Disallow: /*?*oldid=
+
+# Block Special pages (dynamic, resource-intensive, no SEO value)
+Disallow: /w/Special:
+Disallow: /w/Special%3A
+
+# Explicitly allow the article path
+Allow: /w/
+
+# AI and scraper bot blocks
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+# XML Sitemap location
+Sitemap: https://consumerrights.wiki/sitemap/sitemap-index-consumerrights.xml


### PR DESCRIPTION
## Summary

Addresses the site's complete lack of Google rankings despite 8+ months live, 1,279 articles, and 213 active contributors. Root cause: a 3.7:1 junk-to-content indexing ratio (~4,673 non-content pages indexable) triggering Google's Helpful Content site-wide ranking suppression.

This PR implements 9 items from the SEO recovery action plan across indexation control, OpenGraph metadata, crawl efficiency, and mobile parity.

### Changes

**Indexation control (eliminates junk pages from Google's index):**
- `$wgNamespaceRobotPolicies` — noindex 13 non-content namespaces (Talk, User, Help, Project, etc.)
- Thin category conditional noindex — categories with <5 members get noindexed (self-healing)
- Stub article conditional noindex — articles under 2,000 bytes get noindexed (self-healing)

**OpenGraph & meta descriptions (fixes incomplete social/search metadata):**
- `og:type` meta tag — "article" for content pages, "website" for main page (required by OpenGraph spec)
- Cargo auto meta description — pulls `IncidentCargo.Description` as fallback when no manual `{{#seo:}}` exists
- `$wgWikiSeoDefaultImage` — fallback og:image for social sharing

**Crawl efficiency (stops wasting Google's crawl budget):**
- Physical `robots.txt` baked into Docker image — blocks MW infrastructure URLs + AI scraper bots
- `$wgSitemapNamespaces = [0]` — restricts sitemap to articles only
- `$wgMainPageIsDomainRoot` + nginx rewrite — serves Main Page at `/` instead of double 301 redirect chain

**Mobile & infrastructure:**
- MobileFrontend trust signal settings for E-E-A-T
- Suppress MW 1.44 PHP deprecation notices from leaking into page output

### Files changed

| File | What |
|------|------|
| `conf/LocalSettings/core/Security.php` | `$wgNamespaceRobotPolicies` (13 namespaces) |
| `conf/LocalSettings/customizations/SEO.php` | **New** — 4 BeforePageDisplay hooks (og:type, Cargo description, thin category noindex, stub noindex) |
| `conf/LocalSettings.php` | Registered SEO.php |
| `conf/LocalSettings/extensions/WikiSEO.php` | `$wgWikiSeoDefaultImage` |
| `conf/LocalSettings/core/Paths.php` | `$wgMainPageIsDomainRoot = true` |
| `conf/LocalSettings/core/Namespaces.php` | `$wgSitemapNamespaces = [0]` |
| `conf/nginx.conf` | Domain root rewrite (permanent redirect → internal rewrite to PHP) |
| `robots.txt` | **New** — comprehensive crawler directives |
| `Dockerfile` | COPY robots.txt into image |
| `conf/LocalSettings/extensions/MobileFrontend.php` | Mobile trust signal settings |
| `conf/LocalSettings/core/Debug.php` | Suppress E_DEPRECATED + display_errors |

### Testing

Tested locally against a full production database import (1,279 articles, all Cargo tables, all images):
- ✅ Domain root `/` returns 200 (no 301 redirect)
- ✅ Article routing `/w/*` still works
- ✅ `robots.txt` served correctly
- ✅ Talk/User pages have `noindex,follow`
- ✅ Thin categories have `noindex,follow`
- ✅ Stub articles have `noindex,follow`
- ✅ Full articles do NOT have noindex
- ✅ `og:type` present (article/website)
- ✅ `og:image` fallback present
- ✅ No PHP errors or deprecation warnings in output
- ✅ Docker image builds cleanly

### Post-deploy

After merging and deploying the new image:
1. `make update` — run database migrations
2. `make sitemap` — generate XML sitemap (first time)
3. Submit sitemap to Google Search Console
4. Spot-check: Talk page, User page, thin category, stub article — verify noindex in page source
5. Verify `https://consumerrights.wiki/` serves Main Page directly (no redirect)
6. Verify `https://consumerrights.wiki/robots.txt` returns correct content

### Expected impact

- Google removes ~4,673 junk pages from index over 2–4 weeks
- Helpful Content quality suppression lifts within 4–8 weeks
- First rankings for long-tail queries in 2–4 months
- Broader visibility in 6–12 months as domain trust builds